### PR TITLE
Feature/add GitHub composite action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -20,7 +20,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: "github.com/OGSL-SLGO/ogsl-nextjs-map-template"
-        tag: ${{ inputs.version }}
+        ref: ${{ GITHUB_SHA }}
         token: ${{ inputs.token }}
 
     - name: Clone config repository

--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,7 @@ runs:
       shell: bash
       run: |
         rm -rf config/.git
-        cp -r config/ .
+        cp -r config/* .
 
     - name: Show available files
       run: ls -la

--- a/action.yaml
+++ b/action.yaml
@@ -18,6 +18,7 @@ runs:
   steps:
     - name: Clone catalogue map repository
       run: cp -r "$GITHUB_ACTION_PATH"
+      shell: bash
 
     - name: Clone config repository
       uses: actions/checkout@v4

--- a/action.yaml
+++ b/action.yaml
@@ -4,22 +4,16 @@ inputs:
   token:
     description: 'GitHub token to access the repository'
     required: true
-  source_branch:
-    description: 'Branch to deploy the catalogue map'
-    required: true
-    default: 'main'
-  target_branch:
-    description: 'Branch to deploy the catalogue map'
-    required: true
-    default: 'gh-pages'
 
 runs:
   using: "composite"
   steps:
     - name: Clone catalogue map repository
-      run: cp -r "$GITHUB_ACTION_PATH" .
-      shell: bash
-      
+      with: actions/checkout@v4
+        token: ${{ inputs.token }}
+        repository: "ogsl-slgo/ogsl-nextjs-catalogue-map-template
+        ref: "main
+
     - name: Show available files
       run: ls -la
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -19,7 +19,7 @@ runs:
     - name: Clone catalogue map repository
       uses: actions/checkout@v4
       with:
-        repository: "github.com/OGSL-SLGO/ogsl-nextjs-map-template"
+        repository: "OGSL-SLGO/ogsl-nextjs-map-template"
         ref: ${{ GITHUB_SHA }}
         token: ${{ inputs.token }}
 

--- a/action.yaml
+++ b/action.yaml
@@ -4,7 +4,7 @@ inputs:
   token:
     description: 'GitHub token to access the repository'
     required: true
-
+    
 runs:
   using: "composite"
   steps:
@@ -14,10 +14,6 @@ runs:
         token: ${{ inputs.token }}
         repository: ogsl-slgo/ogsl-nextjs-map-template
         ref: main
-
-    - name: Show available files
-      run: ls -la
-      shell: bash
 
     - name: Clone config repository
       uses: actions/checkout@v4
@@ -30,10 +26,6 @@ runs:
       run: |
         rm -rf config/.git
         cp -r config/* .
-
-    - name: Show available files
-      run: ls -la
-      shell: bash
       
     - name: Set up Node.js
       uses: actions/setup-node@v4

--- a/action.yaml
+++ b/action.yaml
@@ -9,7 +9,8 @@ runs:
   using: "composite"
   steps:
     - name: Clone catalogue map repository
-      with: actions/checkout@v4
+      uses: actions/checkout@v4
+      with:
         token: ${{ inputs.token }}
         repository: "ogsl-slgo/ogsl-nextjs-catalogue-map-template
         ref: "main

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,10 @@ runs:
     - name: Clone catalogue map repository
       run: cp -r "$GITHUB_ACTION_PATH" .
       shell: bash
+      
+    - name: Show available files
+      run: ls -la
+      shell: bash
 
     - name: Clone config repository
       uses: actions/checkout@v4

--- a/action.yaml
+++ b/action.yaml
@@ -1,14 +1,9 @@
 name: 'Build Catalogue Map'
 description: 'Generate a catalogue map'
 inputs:
-  version:  # id of input
-    description: 'Tag version to be used for the catalogue map'
-    required: true
-    default: 'latest'
   token:
     description: 'GitHub token to access the repository'
     required: true
-    default: ${{ secrets.GITHUB_TOKEN }}
   source_branch:
     description: 'Branch to deploy the catalogue map'
     required: true

--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: "22"
+        node-version: 22
 
     - name: Install Dependencies
       run: npm ci

--- a/action.yaml
+++ b/action.yaml
@@ -17,7 +17,7 @@ runs:
   using: "composite"
   steps:
     - name: Clone catalogue map repository
-      run: cp -r "$GITHUB_ACTION_PATH"
+      run: cp -r "$GITHUB_ACTION_PATH" .
       shell: bash
 
     - name: Clone config repository

--- a/action.yaml
+++ b/action.yaml
@@ -28,9 +28,13 @@ runs:
     
     - name: Copy config
       run: |
-        rm -rf ../.git
+        rm -rf ../config/.git
         cp -r ../config/. .
 
+    - name: Show available files
+      run: ls -la
+      shell: bash
+      
       shell: bash
     - name: Set up Node.js
       uses: actions/setup-node@v4

--- a/action.yaml
+++ b/action.yaml
@@ -13,7 +13,7 @@ runs:
       with:
         token: ${{ inputs.token }}
         repository: "ogsl-slgo/ogsl-nextjs-catalogue-map-template
-        ref: "main
+        ref: main
 
     - name: Show available files
       run: ls -la

--- a/action.yaml
+++ b/action.yaml
@@ -17,17 +17,20 @@ runs:
   using: "composite"
   steps:
     - name: Clone catalogue map repository
-      uses: actions/checkout@v4
-      with:
-        repository: "OGSL-SLGO/ogsl-nextjs-map-template"
-        ref: ${{ GITHUB_SHA }}
-        token: ${{ inputs.token }}
+      run: cp -r "$GITHUB_ACTION_PATH"
 
     - name: Clone config repository
       uses: actions/checkout@v4
       with:
         token: ${{ inputs.token }}
+        path: ../config
     
+    - name: Copy config
+      run: |
+        rm -rf ../.git
+        cp -r ../config/. .
+
+      shell: bash
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
@@ -45,16 +48,15 @@ runs:
       run: npm run build
       shell: bash
     
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+
     - name: Upload artifact
-      if: ${{ inputs.source_branch == github.ref_name }}
       uses: actions/upload-pages-artifact@v3
       with:
-        path: ./out
+        path: "out"
 
     - name: Deploy to GitHub Pages
-      if: ${{ inputs.source_branch == github.ref_name }}
       id: deployment
       uses: actions/deploy-pages@v4
-      with:
-        token: ${{ inputs.token }}
-        branch: ${{ inputs.target_branch }}
+

--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ runs:
       uses: actions/checkout@v4
       with:
         token: ${{ inputs.token }}
-        repository: ogsl-slgo/ogsl-nextjs-catalogue-map-template
+        repository: ogsl-slgo/ogsl-nextjs-map-template
         ref: main
 
     - name: Show available files

--- a/action.yaml
+++ b/action.yaml
@@ -24,13 +24,13 @@ runs:
       uses: actions/checkout@v4
       with:
         token: ${{ inputs.token }}
-        path: ../config
+        path: config
     
     - name: Copy config
       shell: bash
       run: |
-        rm -rf ../config/.git
-        cp -r ../config/ .
+        rm -rf config/.git
+        cp -r config/ .
 
     - name: Show available files
       run: ls -la

--- a/action.yaml
+++ b/action.yaml
@@ -12,7 +12,7 @@ runs:
       uses: actions/checkout@v4
       with:
         token: ${{ inputs.token }}
-        repository: "ogsl-slgo/ogsl-nextjs-catalogue-map-template
+        repository: ogsl-slgo/ogsl-nextjs-catalogue-map-template
         ref: main
 
     - name: Show available files

--- a/action.yaml
+++ b/action.yaml
@@ -27,6 +27,7 @@ runs:
         path: ../config
     
     - name: Copy config
+      shell: bash
       run: |
         rm -rf ../config/.git
         cp -r ../config/. .

--- a/action.yaml
+++ b/action.yaml
@@ -58,7 +58,7 @@ runs:
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3
       with:
-        path: "out"
+        path: out
 
     - name: Deploy to GitHub Pages
       id: deployment

--- a/action.yaml
+++ b/action.yaml
@@ -30,7 +30,7 @@ runs:
       shell: bash
       run: |
         rm -rf ../config/.git
-        cp -r ../config/. .
+        cp -r ../config/ .
 
     - name: Show available files
       run: ls -la

--- a/action.yaml
+++ b/action.yaml
@@ -36,7 +36,6 @@ runs:
       run: ls -la
       shell: bash
       
-      shell: bash
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -1,0 +1,65 @@
+name: 'Build Catalogue Map'
+description: 'Generate a catalogue map'
+inputs:
+  version:  # id of input
+    description: 'Tag version to be used for the catalogue map'
+    required: true
+    default: 'latest'
+  token:
+    description: 'GitHub token to access the repository'
+    required: true
+    default: ${{ secrets.GITHUB_TOKEN }}
+  source_branch:
+    description: 'Branch to deploy the catalogue map'
+    required: true
+    default: 'main'
+  target_branch:
+    description: 'Branch to deploy the catalogue map'
+    required: true
+    default: 'gh-pages'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Clone catalogue map repository
+      uses: actions/checkout@v4
+      with:
+        repository: "github.com/OGSL-SLGO/ogsl-nextjs-map-template"
+        tag: ${{ inputs.version }}
+        token: ${{ inputs.token }}
+
+    - name: Clone config repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ inputs.token }}
+    
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: "22"
+
+    - name: Install Dependencies
+      run: npm ci
+      shell: bash
+
+    - name: Run Lint
+      run: npm run lint
+      shell: bash
+
+    - name: Build Static Files
+      run: npm run build
+      shell: bash
+    
+    - name: Upload artifact
+      if: ${{ inputs.source_branch == github.ref_name }}
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: ./out
+
+    - name: Deploy to GitHub Pages
+      if: ${{ inputs.source_branch == github.ref_name }}
+      id: deployment
+      uses: actions/deploy-pages@v4
+      with:
+        token: ${{ inputs.token }}
+        branch: ${{ inputs.target_branch }}


### PR DESCRIPTION
This pull request adds a new GitHub Action workflow for building and deploying a catalogue map. The workflow automates the process of cloning repositories, setting up the environment, building the project, and deploying the output to GitHub Pages.

**Catalogue Map Build and Deployment Workflow:**

* Adds a new composite GitHub Action in `action.yaml` that defines the steps to generate and deploy a catalogue map.

**Repository Management:**

* Clones the main catalogue map repository (`ogsl-slgo/ogsl-nextjs-map-template`) and a separate config repository, then copies the config files into the working directory.

**Environment Setup and Build:**

* Sets up Node.js (version 22), installs dependencies, runs lint checks, and builds static files using npm scripts.

**Deployment to GitHub Pages:**

* Configures GitHub Pages, uploads the build artifacts, and deploys the static site using the latest GitHub Actions for pages deployment.