### PR TITLE
Add configurable label overlays for map layers

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -101,7 +101,7 @@ function AppContent({ lang, setLang }) {
         lang,
       );
     }
-  }, [allItems,lang]);
+  }, [allItems, lang]);
 
   // Use callback for fetching data
   const fetchData = useCallback(async () => {
@@ -143,7 +143,7 @@ function AppContent({ lang, setLang }) {
     if (selectedDateFilterOption) {
       setSelectedDateFilterOption("");
     }
-  }, [allItems, badges,selectedDateFilterOption]);
+  }, [allItems, badges, selectedDateFilterOption]);
 
   // Fonction pour charger et filtrer les EOVs traduits
   const fetchAndFilterEovsTranslated = useCallback(async (lang, eovList) => {
@@ -159,9 +159,7 @@ function AppContent({ lang, setLang }) {
     setTranslatedEovList(filtered);
   }, []);
 
-
-
-    // Memoize callbacks to prevent re-renders
+  // Memoize callbacks to prevent re-renders
   const handleListItemClick = useCallback(
     (selectedItem) => {
       setBounds(selectedItem.spatial);
@@ -180,7 +178,10 @@ function AppContent({ lang, setLang }) {
         manageURLParametersOnLoad(setBadges);
         selectedId = window.location.hash.replace(/^#/, "");
       }
-      console.log("All items loaded, managing URL parameters NON ::: ", selectedId);
+      console.log(
+        "All items loaded, managing URL parameters NON ::: ",
+        selectedId,
+      );
       if (selectedId) {
         const selectedItem = allItems.find((item) => item.id === selectedId);
         if (selectedItem && selectedItem.spatial) {
@@ -190,8 +191,6 @@ function AppContent({ lang, setLang }) {
       }
     }
   }, [allItems]);
-
-
 
   // This effect updates the map bounds when datasetSpatial changes
   // It ensures that the map is updated only when the mapRef is ready
@@ -232,8 +231,6 @@ function AppContent({ lang, setLang }) {
     }
   }, [lang, eovList, fetchAndFilterEovsTranslated]);
 
-
-
   // Add this function to remove the hash fragment from the URL
   function removeURLFragment() {
     console.log("Removing URL fragment");
@@ -250,22 +247,23 @@ function AppContent({ lang, setLang }) {
 
   useEffect(() => {
     console.log("Drawer state changed:", isDrawerOpen);
-
+    // We only want to perform cleanup when transitioning from open -> closed
     if (prevDrawerOpen.current && !isDrawerOpen) {
+      // Remove the hash fragment so deep-link is cleared when user dismisses details
       removeURLFragment();
-      // Recenter the map to default center and zoom when drawer closes
+
+      // Clear any polygon / geojson highlight layers we drew, but DO NOT recenter the map
       if (
         mapRef.current &&
-        typeof mapRef.current.recenterToDefault === "function"
+        typeof mapRef.current.clearMapLayers === "function"
       ) {
-        mapRef.current.recenterToDefault();
+        mapRef.current.clearMapLayers();
       }
+
+      // Reset bounds so that selecting the same dataset again will still trigger FitBounds
+      setBounds(null);
     }
-    // Drawer just closed, recenter map to config center when drawer closes
-    if (mapRef.current && typeof mapRef.current.clearMapLayers === "function") {
-      mapRef.current.clearMapLayers();
-    }
-    setBounds(null); // Reset bounds when drawer closes
+    // Update previous state ref AFTER handling logic
     prevDrawerOpen.current = isDrawerOpen;
   }, [isDrawerOpen]);
 

--- a/components/Map.js
+++ b/components/Map.js
@@ -158,6 +158,15 @@ const BaseLayers = ({ basemaps, lang }) => (
           minZoom={layer.minZoom || 0}
           maxZoom={layer.maxZoom || 10}
         />
+        {/* Optional label overlay (cities, place names) rendered on top of base tiles */}
+        {layer.label_url ? (
+          <TileLayer
+            url={layer.label_url}
+            attribution={layer.attribution}
+            minZoom={layer.minZoom || 0}
+            maxZoom={layer.maxZoom || 10}
+          />
+        ) : null}
       </BaseLayer>
     ))}
   </>

--- a/components/Map.js
+++ b/components/Map.js
@@ -163,8 +163,23 @@ const BaseLayers = ({ basemaps, lang }) => (
           <TileLayer
             url={layer.label_url}
             attribution={layer.attribution}
-            minZoom={layer.minZoom || 0}
-            maxZoom={layer.maxZoom || 10}
+            minZoom={
+              typeof layer.label_minZoom !== "undefined"
+                ? layer.label_minZoom
+                : layer.minZoom || 0
+            }
+            maxZoom={
+              typeof layer.label_maxZoom !== "undefined"
+                ? layer.label_maxZoom
+                : layer.maxZoom || 18
+            }
+            opacity={
+              typeof layer.label_opacity !== "undefined"
+                ? layer.label_opacity
+                : 0.9
+            }
+            // zIndex ensures labels render above the base tiles but below markers/controls
+            zIndex={650}
           />
         ) : null}
       </BaseLayer>

--- a/config.yaml
+++ b/config.yaml
@@ -103,10 +103,6 @@ basemaps:
       en: "Bathymetry"
     key: "bathymetry"
     url: "https://server.arcgisonline.com/ArcGIS/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}"
-    # Optional per-label control
-    label_minZoom: 2
-    label_maxZoom: 18
-    label_opacity: 0.85
     attribution: "Tiles &copy; Esri &mdash; Sources: GEBCO, NOAA, CHS, OSU, UNH, CSUMB, National Geographic, DeLorme, NAVTEQ, and Esri"
     checked: true
     maxZoom: 10
@@ -117,6 +113,14 @@ basemaps:
     url: "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
     attribution: "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
 
+overlays:
+  - name:
+      fr: "Limites administratives"
+      en: "Administrative Boundaries"
+    key: "admin_boundaries"
+    url: "https://services.arcgisonline.com/arcgis/rest/services/Ocean/World_Ocean_Reference/MapServer/tile/{z}/{y}/{x}"
+    attribution: "Data &copy; Esri, HERE, Garmin, USGS, NGA, EPA, USDA, NPS"
+    checked: true
 # Pages Configuration
 # ==========================
 # This section defines the pages that will be available in the application.

--- a/config.yaml
+++ b/config.yaml
@@ -103,8 +103,10 @@ basemaps:
       en: "Bathymetry"
     key: "bathymetry"
     url: "https://server.arcgisonline.com/ArcGIS/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}"
-    # Optional label overlay to show cities/places on top of the base tiles
-    label_url: "https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}"
+    # Optional per-label control
+    label_minZoom: 2
+    label_maxZoom: 18
+    label_opacity: 0.85
     attribution: "Tiles &copy; Esri &mdash; Sources: GEBCO, NOAA, CHS, OSU, UNH, CSUMB, National Geographic, DeLorme, NAVTEQ, and Esri"
     checked: true
     maxZoom: 10

--- a/config.yaml
+++ b/config.yaml
@@ -115,9 +115,9 @@ basemaps:
 
 overlays:
   - name:
-      fr: "Limites administratives"
-      en: "Administrative Boundaries"
-    key: "admin_boundaries"
+      fr: "Noms géographiques"
+      en: "Geographic Names"
+    key: "geographic_names"
     url: "https://services.arcgisonline.com/arcgis/rest/services/Ocean/World_Ocean_Reference/MapServer/tile/{z}/{y}/{x}"
     attribution: "Data &copy; Esri, HERE, Garmin, USGS, NGA, EPA, USDA, NPS"
     checked: true

--- a/config.yaml
+++ b/config.yaml
@@ -103,6 +103,8 @@ basemaps:
       en: "Bathymetry"
     key: "bathymetry"
     url: "https://server.arcgisonline.com/ArcGIS/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}"
+    # Optional label overlay to show cities/places on top of the base tiles
+    label_url: "https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}"
     attribution: "Tiles &copy; Esri &mdash; Sources: GEBCO, NOAA, CHS, OSU, UNH, CSUMB, National Geographic, DeLorme, NAVTEQ, and Esri"
     checked: true
     maxZoom: 10


### PR DESCRIPTION
This pull request introduces support for configurable map overlays in addition to basemaps, along with improvements to the map drawer closing logic and minor code cleanups. The most significant changes are the addition of overlay configuration and rendering, which enables features like geographic name labels on the map.

**Map overlay support:**

* Added an `overlays` section to `config.yaml` allowing overlays such as "Geographic Names" to be defined and enabled.
* Implemented a new `Overlays` component in `components/Map.js` to render overlays from config, supporting both raster and vector tile overlays.
* Integrated the `Overlays` component into the main map rendering, so overlays appear in the layers control alongside basemaps.
* Imported `VectorBasemap` from `react-leaflet` to support vector tile overlays.

**Map drawer closing logic improvements:**

* Updated the drawer close logic in `app/layout.js` to clear map highlight layers and reset bounds only when the drawer transitions from open to closed, without recentering the map. This ensures a smoother user experience when dismissing dataset details.

**Minor code cleanups:**

* Removed unnecessary blank lines and improved formatting for better readability in `app/layout.js`. [[1]](diffhunk://#diff-28d6371ce6a935bbbf260c960c211c40eb5a4faa836dd266fa053996b6212cefL162-L163) [[2]](diffhunk://#diff-28d6371ce6a935bbbf260c960c211c40eb5a4faa836dd266fa053996b6212cefL194-L195) [[3]](diffhunk://#diff-28d6371ce6a935bbbf260c960c211c40eb5a4faa836dd266fa053996b6212cefL235-L236)
* Improved logging statement formatting for clarity.Introduce optional label overlays for cities and places on base tiles, along with configurable options for overlays in map layers. Update overlay names for improved clarity in geographic context.