### PR TITLE
changed the handleMouseOver function to not display a polygon if the …

### DIFF
--- a/components/Map.js
+++ b/components/Map.js
@@ -110,6 +110,9 @@ const DatasetMarker = ({ record, handleListItemClick, lang, openDrawer }) => {
     // Only add polygon if it doesn't already exist
     if (e.target._hoverPolygon) return;
 
+    // Skip drawing polygon for point geometries (causes flickering)
+    if (record.spatial.type === "Point") return;
+
     const map = e.target._map;
     const polygon = L.geoJSON(record.spatial, {
       style: {


### PR DESCRIPTION
Simple one line change to prevent flicking. If the spatial type is a point, then no need to draw polygon. 