### PR TITLE
Fixed flickering of metadata that are defined as a point instead of a polygon

### DIFF
--- a/components/Map.js
+++ b/components/Map.js
@@ -110,6 +110,9 @@ const DatasetMarker = ({ record, handleListItemClick, lang, openDrawer }) => {
     // Only add polygon if it doesn't already exist
     if (e.target._hoverPolygon) return;
 
+    // Skip drawing polygon for point geometries (causes flickering)
+    if (record.spatial.type === "Point") return;
+
     const map = e.target._map;
     const polygon = L.geoJSON(record.spatial, {
       style: {


### PR DESCRIPTION
One line change. If spatial data is defined as a point, then don't don't try to draw a polygon .